### PR TITLE
refactor: use AppUserRequestDTO in AppUserController

### DIFF
--- a/src/main/kotlin/es/in2/wallet/api/controller/AppUserController.kt
+++ b/src/main/kotlin/es/in2/wallet/api/controller/AppUserController.kt
@@ -1,8 +1,9 @@
 package es.in2.wallet.api.controller
 
-import es.in2.wallet.api.model.entity.AppUser
 import es.in2.wallet.api.model.dto.AppUserRequestDTO
+import es.in2.wallet.api.model.dto.AppUserResponseDTO
 import es.in2.wallet.api.service.AppUserService
+import es.in2.wallet.api.util.ApplicationUtils.toAppUserResponseDTO
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.websocket.server.PathParam
 import org.slf4j.Logger
@@ -27,25 +28,25 @@ class AppUserController(
         appUserService.registerUser(appUserRequestDTO)
     }
 
-    // fixme: this method should return List<AppUserResponseDTO>
     @GetMapping
-    fun getAllUsers(): List<AppUser> {
+    fun getAllUsers(): List<AppUserResponseDTO> {
         log.debug("AppUserController.getAllUsers()")
-        return appUserService.getUsers()
+        return appUserService.getUsers().map { it.toAppUserResponseDTO() }
     }
 
-    // fixme: this method should return an AppUserResponseDTO
     @GetMapping("/uuid")
-    fun getUserByUUID(@PathParam("uuid") uuid: String): Optional<AppUser> {
+    fun getUserByUUID(@PathParam("uuid") uuid: String): Optional<AppUserResponseDTO> {
         log.debug("AppUserController.getUserByUUID()")
+
         return appUserService.getUserById(UUID.fromString(uuid))
+            .map { it.toAppUserResponseDTO() }
     }
 
-    // fixme: this method should return an AppUserResponseDTO
     @GetMapping("/username")
-    fun getUserByUsername(@PathParam("username") username: String): Optional<AppUser> {
+    fun getUserByUsername(@PathParam("username") username: String): Optional<AppUserResponseDTO> {
         log.debug("AppUserController.getUserByUsername()")
         return appUserService.getUserByUsername(username)
+            .map { it.toAppUserResponseDTO() }
     }
 
 }

--- a/src/main/kotlin/es/in2/wallet/api/util/ApplicationUtils.kt
+++ b/src/main/kotlin/es/in2/wallet/api/util/ApplicationUtils.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import es.in2.wallet.api.exception.FailedCommunicationException
+import es.in2.wallet.api.model.dto.AppUserResponseDTO
 import es.in2.wallet.api.model.dto.OpenIdConfig
+import es.in2.wallet.api.model.entity.AppUser
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -175,4 +177,9 @@ object ApplicationUtils {
         return objectMapper.writeValueAsString(data)
     }
 
+    fun AppUser.toAppUserResponseDTO() = AppUserResponseDTO(
+        uuid = id.toString(),
+        username = username,
+        email = email
+    )
 }

--- a/src/test/kotlin/es/in2/wallet/controller/AppUserControllerTest.kt
+++ b/src/test/kotlin/es/in2/wallet/controller/AppUserControllerTest.kt
@@ -71,7 +71,7 @@ class AppUserControllerTest {
     // @Get /api/users
 
     @Test
-    fun `getAllUsers should return a list of AppUser`() {
+    fun `getAllUsers should return a list of AppUserResponseDTO`() {
         val users = listOf(appUser, appUser2)
 
         given(appUserService.getUsers()).willReturn(users)
@@ -81,8 +81,12 @@ class AppUserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$[0].username").value("jdoe"))
-            .andExpect(jsonPath("$[1].username").value("janeDoe"))
+            .andExpect(jsonPath("$[0].uuid").value(appUser.id.toString()))
+            .andExpect(jsonPath("$[0].username").value(appUser.username))
+            .andExpect(jsonPath("$[0].email").value(appUser.email))
+            .andExpect(jsonPath("$[1].uuid").value(appUser2.id.toString()))
+            .andExpect(jsonPath("$[1].username").value(appUser2.username))
+            .andExpect(jsonPath("$[1].email").value(appUser2.email))
     }
 
     // @Get /api/users/{uuid}
@@ -92,7 +96,7 @@ class AppUserControllerTest {
         given(appUserService.getUserById(uuid)).willReturn(Optional.of(appUser))
         mockMvc.perform(MockMvcRequestBuilders.get("/api/users/uuid?uuid=$uuid"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.id").value(uuid.toString()))
+            .andExpect(jsonPath("$.uuid").value(uuid.toString()))
             .andExpect(jsonPath("$.username").value("jdoe"))
             .andExpect(jsonPath("$.email").value("jdoe@example.com"))
     }
@@ -104,7 +108,7 @@ class AppUserControllerTest {
         given(appUserService.getUserByUsername(appUser.username)).willReturn(Optional.of(appUser))
         mockMvc.perform(MockMvcRequestBuilders.get("/api/users/username?username=${appUser.username}"))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.id").value(uuid.toString()))
+            .andExpect(jsonPath("$.uuid").value(uuid.toString()))
             .andExpect(jsonPath("$.username").value("jdoe"))
             .andExpect(jsonPath("$.email").value("jdoe@example.com"))
     }


### PR DESCRIPTION
Fixed the `fixme`s related to returning `AppUserResponseDTO` instead of `AppUser` in `AppUserController`.

However it introduces a breaking change in the return format.
Old response (using `AppUser`) :
```
{
  "id": "string",
  "username": "string",
  "email": "string"
}
```

New response (using `AppUserResponseDTO`) :
```
{
  "uuid": "string",
  "username": "string",
  "email": "string"
}
```

Is there any place (in frontend app form example where this change must be handled) ?

EDIT: we could also change the field `uuid` to `id` in the `AppUserResponseDTO` data class : 
```
data class AppUserResponseDTO(
    val id: String,
    val username: String,
    val email: String,
)
```