### PR TITLE
refactor: replace DidResponseDTO with DidRequestDTO in deleteDid

### DIFF
--- a/src/main/kotlin/es/in2/wallet/integration/orion/service/OrionService.kt
+++ b/src/main/kotlin/es/in2/wallet/integration/orion/service/OrionService.kt
@@ -1,5 +1,6 @@
 package es.in2.wallet.integration.orion.service
 
+import es.in2.wallet.wca.model.dto.DidRequestDTO
 import es.in2.wallet.wca.model.entity.DidMethods
 import es.in2.wallet.wca.model.dto.DidResponseDTO
 import es.in2.wallet.wca.model.dto.VcBasicDataDTO
@@ -15,10 +16,7 @@ interface OrionService {
     fun deleteVCs()
     fun saveDid(did: String, didMethod: DidMethods)
     fun getDidsByUserId(): MutableList<DidResponseDTO>
-    fun deleteSelectedDid(didResponseDTO: DidResponseDTO)
-
-
-
+    fun deleteSelectedDid(didRequestDTO: DidRequestDTO)
 }
 
 

--- a/src/main/kotlin/es/in2/wallet/integration/orion/service/impl/OrionServiceImpl.kt
+++ b/src/main/kotlin/es/in2/wallet/integration/orion/service/impl/OrionServiceImpl.kt
@@ -13,6 +13,7 @@ import es.in2.wallet.integration.orion.model.VerifiableCredentialEntity
 import es.in2.wallet.integration.orion.service.OrionService
 import es.in2.wallet.wca.exception.DIDNotFoundException
 import es.in2.wallet.wca.exception.InvalidDidFormatException
+import es.in2.wallet.wca.model.dto.DidRequestDTO
 import es.in2.wallet.wca.model.dto.DidResponseDTO
 import es.in2.wallet.wca.model.dto.VcBasicDataDTO
 import es.in2.wallet.wca.model.entity.DidMethods
@@ -274,25 +275,25 @@ class OrionServiceImpl(
         return result
     }
 
-    override fun deleteSelectedDid(didResponseDTO: DidResponseDTO) {
+    override fun deleteSelectedDid(didRequestDTO: DidRequestDTO) {
         val userUUID = getUserIdFromContextAuthentication()
-        didExists(didResponseDTO, userUUID)
+        didExists(didRequestDTO, userUUID)
         applicationUtils.deleteRequest(
-            url = "$contextBrokerEntitiesURL/${didResponseDTO.did}?userId.value=$userUUID",
+            url = "$contextBrokerEntitiesURL/${didRequestDTO.value}?userId.value=$userUUID",
             headers = listOf()
         )
     }
 
-    private fun didExists(didResponseDTO: DidResponseDTO, userUUID: String): Boolean {
+    private fun didExists(didRequestDTO: DidRequestDTO, userUUID: String): Boolean {
         try {
             val response = applicationUtils.getRequest(
-                url = "$contextBrokerEntitiesURL/${didResponseDTO.did}?userId.value=$userUUID",
+                url = "$contextBrokerEntitiesURL/${didRequestDTO.value}?userId.value=$userUUID",
                 headers = listOf()
             )
             return response.isNotEmpty()
 
         } catch (e: NoSuchElementException) {
-            throw DIDNotFoundException("DID not found: ${didResponseDTO.did}")
+            throw DIDNotFoundException("DID not found: ${didRequestDTO.value}")
         }
     }
 

--- a/src/main/kotlin/es/in2/wallet/wca/controller/DidController.kt
+++ b/src/main/kotlin/es/in2/wallet/wca/controller/DidController.kt
@@ -49,8 +49,6 @@ class DidController(
         return walletDidService.getDidsByUserId()
     }
 
-
-    // fixme: deleteDid() should use a DidRequestDTO not a DidResponseDTO
     @DeleteMapping
     @ResponseStatus(HttpStatus.OK)
     @Operation(
@@ -63,8 +61,8 @@ class DidController(
         ApiResponse(responseCode = "400", description = "Invalid request."),
         ApiResponse(responseCode = "500", description = "Internal server error.")
     ])
-    fun deleteDid(@RequestBody didResponseDTO: DidResponseDTO): String {
-        walletDidService.deleteDid(didResponseDTO)
+    fun deleteDid(@RequestBody didRequestDTO: DidRequestDTO): String {
+        walletDidService.deleteDid(didRequestDTO)
         return "DID deleted"
     }
 

--- a/src/main/kotlin/es/in2/wallet/wca/service/WalletDidService.kt
+++ b/src/main/kotlin/es/in2/wallet/wca/service/WalletDidService.kt
@@ -8,7 +8,6 @@ interface WalletDidService {
     fun generateDidKey(): String
     fun generateDidKeyWithKid(kid: String): String
     fun getDidsByUserId(): List<DidResponseDTO>
-    // fixme: deleteDid() should use a DidRequestDTO not a DidResponseDTO
-    fun deleteDid(didResponseDTO: DidResponseDTO): String
+    fun deleteDid(didRequestDTO: DidRequestDTO): String
 }
 

--- a/src/main/kotlin/es/in2/wallet/wca/service/impl/WalletDidServiceImpl.kt
+++ b/src/main/kotlin/es/in2/wallet/wca/service/impl/WalletDidServiceImpl.kt
@@ -68,13 +68,17 @@ class WalletDidServiceImpl(
         return orionService.getDidsByUserId()
     }
 
-    override fun deleteDid(didResponseDTO: DidResponseDTO): String{
-        val did = didResponseDTO.did
-        if(!did.startsWith("did:key:") && !did.startsWith("did:elsi:")){
-            throw InvalidDidFormatException("Value DID has an invalid format.")
+    override fun deleteDid(didRequestDTO: DidRequestDTO): String{
+        val didType = didRequestDTO.type
+        val did = didRequestDTO.value
+
+        when (didType) {
+            "key", "elsi" -> {
+                orionService.deleteSelectedDid(didRequestDTO)
+                return "Deleted " + did
+            }
+            else -> throw InvalidDidFormatException("Invalid DID format")
         }
-        orionService.deleteSelectedDid(didResponseDTO)
-        return "Deleted " + didResponseDTO.did
     }
 
     override fun generateDidKey(): String {

--- a/src/test/kotlin/es/in2/wallet/controller/DidControllerTest.kt
+++ b/src/test/kotlin/es/in2/wallet/controller/DidControllerTest.kt
@@ -164,13 +164,14 @@ class DidControllerTest {
 
     @Test
     fun `Delete Did should return 200 OK`() {
-        val did = DidResponseDTO("did:key:zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97")
+        val didRequestDTO = DidRequestDTO("key", "zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97")
         val userUUID = "fff36f29-2155-4647-aacf-e01e6f54cc91"
-        Mockito.`when`(didController.deleteDid(did)).thenReturn("DID deleted")
+        Mockito.`when`(didController.deleteDid(didRequestDTO)).thenReturn("DID deleted")
 
         val jsonRequestDTO = """
             {
-                "did": "did:key:zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97"
+                "type": "key",
+                "value": "zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97"
             }
         """.trimIndent()
 
@@ -187,14 +188,15 @@ class DidControllerTest {
 
     @Test
     fun `Delete Did should return 500 INTERNAL SERVER ERROR`() {
-        val didResponseDTO = DidResponseDTO("did:key:zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97")
+        val didRequestDTO = DidRequestDTO("key", "zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97")
         val errorMessage = "DID not found: did:key:sdsdsdsdsdsdsdsdsdsdsdsd"
         val userUUID = "fff36f29-2155-4647-aacf-e01e6f54cc91"
-        Mockito.`when`(didController.deleteDid(didResponseDTO))
+        Mockito.`when`(didController.deleteDid(didRequestDTO))
 
         val jsonRequestDTO = """
             {
-                "did": "did:key:sdsdsdsdsdsdsdsdsdsdsdsd"
+                "type": "key",
+                "value": "sdsdsdsdsdsdsdsdsdsdsdsd"
             }
         """.trimIndent()
 


### PR DESCRIPTION
Fixed the `fixme`s related to using `DidResponseDTO` instead of `DidRequestDTO` in `AppUserController::deleteDid`.

Same remark as #1 , this PR introduces a breaking change in the request format.
Old request (using `DidResponseDTO`) :
```
{
  "did": "did:key:zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97"
}
```

New response (using `DidRequestDTO`) :
```
{
  "type": "key",
  "value": "zDnaeucFNSnCmRGj5VucjxJEJS6yhF9PtnfSjCyBMGza2Wt97"
}
```